### PR TITLE
More `date` fixes

### DIFF
--- a/scripts/issues-percentage-replied-last-90-days.sh
+++ b/scripts/issues-percentage-replied-last-90-days.sh
@@ -15,7 +15,7 @@ if [ "$ISSUES_CREATED_LAST_90_DAYS" != [] ]; then
       ISSUE_OPENED_DATE=$(jq '. | .createdAt' <<< $ISSUE_DETAILS)
 
       # get relative datetime 3 days after issue opened
-      THREE_DAYS_AFTER_ISSUE_OPENED=$(date -j -v+3d -f "%Y-%m-%dT%H:%M:%SZ" "${ISSUE_OPENED_DATE//\"}" "+%Y-%m-%dT%H:%M:%SZ")
+      THREE_DAYS_AFTER_ISSUE_OPENED=$(date -u -d"${ISSUE_OPENED_DATE//\"} +3 days" "+%Y-%m-%dT%H:%M:%SZ")
 
       # get number of comments by maintainers within the first 3 days
       # NB: manually filter out apollo-cla bot, but otherwise include all users

--- a/scripts/prs-percentage-replied-last-90-days.sh
+++ b/scripts/prs-percentage-replied-last-90-days.sh
@@ -14,7 +14,7 @@ do
     PR_OPENED_DATE=$(jq '. | .createdAt' <<< $PR_DETAILS)
 
     # get relative datetime 3 days after issue opened
-    THREE_DAYS_AFTER_PR_OPENED=$(date -j -v+3d -f "%Y-%m-%dT%H:%M:%SZ" "${PR_OPENED_DATE//\"}" "+%Y-%m-%dT%H:%M:%SZ")
+    THREE_DAYS_AFTER_PR_OPENED=$(date -u -d"${PR_OPENED_DATE//\"} +3 days" "+%Y-%m-%dT%H:%M:%SZ")
     
     PR_REVIEW_COMMENTS=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "/repos/apollographql/${REPOSITORY}/pulls/${pr//,}/comments")
     


### PR DESCRIPTION
I missed these on the first pass.  I verified the output locally using `gdate` on sample PRs and Issues but that's the extent of the testing.