### PR TITLE
chore: revert change to two scripts, in daily rollups we can ignore closed issues/prs

### DIFF
--- a/.github/workflows/apollo-ios-repo-stats.yml
+++ b/.github/workflows/apollo-ios-repo-stats.yml
@@ -68,7 +68,7 @@ jobs:
         run: cd ${GITHUB_WORKSPACE}/apollo-ios-dev && bash ${GITHUB_WORKSPACE}/main/scripts/prs-percentage-replied-last-72-hours.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IGNORE_USERS: "-author:calvincestari -author:AnthonyMDev -author:BobaFetters"
+          IGNORE_USERS: "-author:calvincestari -author:AnthonyMDev -author:BobaFetters -author:svc-secops"
           REPOSITORY: apollo-ios-dev
 
       - name: Run issues-percentage-replied-last-72-hours.sh

--- a/scripts/issues-percentage-replied-last-72-hours.sh
+++ b/scripts/issues-percentage-replied-last-72-hours.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ISSUES_CREATED_LAST_3_DAYS=$(gh issue list --search "${FILTERED_OUT_LABELS} ${FILTERED_OUT_USERS} created:${DATE_3_DAYS_AGO}..${DATE_TODAY}" --state all --limit 1000 --json number --jq '[.[] | .number]')
+ISSUES_CREATED_LAST_3_DAYS=$(gh issue list --search "${FILTERED_OUT_LABELS} ${FILTERED_OUT_USERS} created:${DATE_3_DAYS_AGO}..${DATE_TODAY}" --limit 1000 --json number --jq '[.[] | .number]')
 ISSUES_SLACK_BOT_MESSAGE=""
 NUM_ISSUES_TO_REPLY_TO=0
 

--- a/scripts/prs-percentage-replied-last-72-hours.sh
+++ b/scripts/prs-percentage-replied-last-72-hours.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PRS_CREATED_LAST_3_DAYS=$(gh pr list --search "${FILTERED_OUT_LABELS} ${IGNORE_USERS} created:${DATE_3_DAYS_AGO}..${DATE_TODAY} review:none -is:draft" --limit 1000 --state all --json number --jq '[.[] | .number]')
+PRS_CREATED_LAST_3_DAYS=$(gh pr list --search "${FILTERED_OUT_LABELS} ${IGNORE_USERS} created:${DATE_3_DAYS_AGO}..${DATE_TODAY} review:none -is:draft" --limit 1000 --json number --jq '[.[] | .number]')
 PRS_SLACK_BOT_MESSAGE=""
 NUM_PRS_TO_REPLY_TO=0
 


### PR DESCRIPTION
In daily repository health check messages, we can ignore issues or PRs that were closed without a comment.

These are rare, and there's usually a reason (maybe they were clearly spam/not engaging with us properly, maybe they were created by an automation and can be quickly closed).

Also, in general the iOS team would like to filter out `svc-secops` created PRs from this view.