### PR TITLE
chore: Update Apollo iOS caretaker handoff time

### DIFF
--- a/.github/workflows/apollo-ios-caretaker-handoff.yml
+++ b/.github/workflows/apollo-ios-caretaker-handoff.yml
@@ -2,8 +2,8 @@ name: apollo-ios-caretaker-handoff
 
 on:
   schedule:
-    # Every Wednesday at 12:00 PM PST
-    - cron: "0 20 * * 3"
+    # Every Wednesday at 10:00 AM PDT / 9:00 AM PST / 1:00 PM EDT / 12:00 PM EST / 5:00 PM UTC
+    - cron: "0 17 * * 3"
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
This change moves it earlier in the day and accounts for some fluctuation in daylight savings time changes too.