### PR TITLE
chore: Update Apollo iOS caretaker handoff message

### DIFF
--- a/.github/workflows/apollo-ios-caretaker-handoff.yml
+++ b/.github/workflows/apollo-ios-caretaker-handoff.yml
@@ -80,7 +80,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Apollo iOS caretaker rotation hand-off :running:\nThanks for your help, <@${{ steps.ios-caretaker-handoff.outputs.OUTGOING_CARETAKER_SLACK_HANDLE }}> / hello again, <@${{ steps.ios-caretaker-handoff.outputs.INCOMING_CARETAKER_SLACK_HANDLE }}> :handshake:\n_Note: This :github: workflow will run every Wednesday at 8PM UTC._"
+                    "text": "Apollo iOS caretaker rotation hand-off :running:\nThanks for your help, <@${{ steps.ios-caretaker-handoff.outputs.OUTGOING_CARETAKER_SLACK_HANDLE }}> / hello again, <@${{ steps.ios-caretaker-handoff.outputs.INCOMING_CARETAKER_SLACK_HANDLE }}> :handshake:\nPlease don't forget to update the @caretaker-ios user group so you will be notified when someone uses it.\n_Note: This :github: workflow will run every Wednesday at 8PM UTC._"
                   }
                 },
                 {


### PR DESCRIPTION
Adds a reminder to the caretaker handoff message to update the Slack user group too.